### PR TITLE
Update prltype to handle special keys

### DIFF
--- a/builder/parallels/common/prltype.go
+++ b/builder/parallels/common/prltype.go
@@ -1,16 +1,16 @@
 package common
 
-// Prltype is a Python scrypt allowin to send scancodes to the VM. It requires
-// the module "prlsdkapi", which is bundled to Parallels Virtualization SDK.
+// Prltype is a Python 2 script that sends scancodes to a Parallels VM. It requires
+// the prlsdkapi Python module, which is bundled with the Parallels Virtualization SDK.
 const Prltype string = `
 import sys
 import prlsdkapi
 
-##
+
 def main():
     if len(sys.argv) < 3:
-       print "Usage: prltype VM_NAME SCANCODE..."
-       sys.exit(1)
+        print "Usage: prltype VM_NAME SCANCODE..."
+        sys.exit(1)
 
     vm_name = sys.argv[1]
     scancodes = sys.argv[2:]
@@ -22,16 +22,16 @@ def main():
 
     disconnect(server, vm, vm_io)
 
-##
+
 def login():
     prlsdkapi.prlsdk.InitializeSDK(prlsdkapi.prlsdk.consts.PAM_DESKTOP_MAC)
     server = prlsdkapi.Server()
-    login_job=server.login_local()
+    login_job = server.login_local()
     login_job.wait()
 
     return server
 
-##
+
 def connect(server, vm_name):
     vm_list_job = server.get_vm_list()
     result = vm_list_job.wait()
@@ -40,8 +40,10 @@ def connect(server, vm_name):
     vm = [vm for vm in vm_list if vm.get_name() == vm_name]
 
     if not vm:
-       vm_names = [vm.get_name() for vm in vm_list]
-       raise Exception("%s: No such VM. Available VM's are:\n%s" % (vm_name, "\n".join(vm_names)))
+        vm_names = [vm.get_name() for vm in vm_list]
+        raise Exception(
+            "%s: No such VM. Available VM's are:\n%s" % (vm_name, "\n".join(vm_names))
+        )
 
     vm = vm[0]
 
@@ -50,7 +52,7 @@ def connect(server, vm_name):
 
     return (vm, vm_io)
 
-##
+
 def disconnect(server, vm, vm_io):
     if vm and vm_io:
         vm_io.disconnect_from_vm(vm)
@@ -60,19 +62,25 @@ def disconnect(server, vm, vm_io):
 
     prlsdkapi.deinit_sdk
 
-##
+
 def send(scancodes, vm, vm_io):
-    timeout = 10
+    delay = 100
     consts = prlsdkapi.prlsdk.consts
 
-    for scancode in scancodes:
-        c = int(scancode, 16)
-        if (c < 128):
-            vm_io.send_key_event(vm, (c,), consts.PKE_PRESS, timeout)
+    for i, scancode in enumerate(scancodes):
+        a = int(scancode, 16)
+        if a == 224: # Scancode sequences start with e0
+            b = int(scancodes.pop(i + 1), 16)
+            if b < 128:
+                vm_io.send_key_event(vm, (a, b), consts.PKE_PRESS, delay)
+            else:
+                vm_io.send_key_event(vm, (a, b - 128), consts.PKE_RELEASE, delay)
+        elif a < 128:
+            vm_io.send_key_event(vm, (a,), consts.PKE_PRESS, delay)
         else:
-            vm_io.send_key_event(vm, (c - 128,) , consts.PKE_RELEASE, timeout)
+            vm_io.send_key_event(vm, (a - 128,), consts.PKE_RELEASE, delay)
 
-##
+
 if __name__ == "__main__":
     main()
 `


### PR DESCRIPTION
## Issue summary

Some special keys (e.g. `RightCrtl`/`RightAlt`/`RightCmd`, arrows, etc) do not work within the `boot_command`. 

## Context

It took me a good amount of time to figure out the different pieces needed to address this bug, so I've overly-documented this PR for those who come after me.

### prltype.py

The `prltype.py` script, which is used to send key events to the Parallels Python API, does not properly send key events for special keys. The problem is that the `prltype.py` script does not recognize scancode sequences, and handles all scancodes as single-hex-character scancodes. Many special keys are represented by scancode sequences. Scancode sequences are typically two hex-characters long and begin with the escape scancode `e0`, with a few exceptions:

- `PAUSE_BREAK` has a scancode > 2 characters and is escaped by `e1`
- `BREAK` has a scancode > 2 characters and is escaped by `e0`
- `PRINT_SCREEN` has a scancode > 2 characters and is escaped by `e0`

These three keys are not included in [the PC-XT driver](https://github.com/hashicorp/packer-plugin-sdk/blob/main/bootcommand/pc_xt_driver.go#L53), nor are they handled in this PR.

For further reading, see the following sections from the scancodes reference at www.win.tue.nl/~aeb/linux/kbd/scancodes-1.html

- 1.3 Escape scancodes
- 1.5 Escaped scancodes

### Parallels APIs

The Parallels Python API is a thin wrapper around the Parallels C API. The C API contains [`PRL_SCAN_CODE_` macros](https://download.parallels.com/desktop/v16/docs/en_US/Parallels%20C%20API%20Reference/PRL_SCAN_CODE_.html) that map variable names to numeric scancodes for each key. The scancodes are sent to the Parallels API as key events (docs: [C](https://download.parallels.com/desktop/v16/docs/en_US/Parallels%20C%20API%20Reference/PrlDevKeyboard_SendKeyEvent@PRL_HANDLE@PRL_UINT32@PRL_KEY_EVENT.html), [Python](https://download.parallels.com/desktop/v16/docs/en_US/Parallels%20Python%20API%20Reference/prlsdkapi.VmIO-class.html)).

To print the Parallels API scancodes, run:

```python
/usr/bin/python -c "import prlsdkapi;import pprint;pp=pprint.PrettyPrinter(indent=2);pp.pprint(prlsdkapi.prlsdk.consts.ScanCodesList)"
```

<details>
  <summary><u>prlsdkapi.prlsdk.consts.ScanCodesList</u></summary>

```python
{
  '0': (11,),
  '1': (2,),
  '2': (3,),
  '3': (4,),
  '4': (5,),
  '5': (6,),
  '6': (7,),
  '7': (8,),
  '8': (9,),
  '9': (10,),
  'A': (30,),
  'ALT_LEFT': (56,),
  'ALT_RIGHT': (224, 56),
  'APP_CALCULATOR': (224, 33),
  'APP_MAIL': (224, 108),
  'APP_MY_COMPUTER': (224, 107),
  'B': (48,),
  'BACKSLASH': (43,),
  'BACKSPACE': (14,),
  'BRAZILIAN_KEYPAD': (126,),
  'BREAK': (224, 70, 224, 198),
  'C': (46,),
  'CAPS_LOCK': (58,),
  'CBRACE_LEFT': (26,),
  'CBRACE_RIGHT': (27,),
  'CMD_LEFT': (224, 91),
  'CMD_RIGHT': (224, 92),
  'COLON': (39,),
  'CTRL_LEFT': (29,),
  'CTRL_RIGHT': (224, 29),
  'D': (32,),
  'DELETE': (224, 83),
  'DOLLAR': (224, 52),
  'DOWN': (224, 80),
  'E': (18,),
  'EJECT': (224, 99),
  'END': (224, 79),
  'ENTER': (28,),
  'ESC': (1,),
  'EURO': (224, 51),
  'EUROPE_1': (43,),
  'F': (33,),
  'F1': (59,),
  'F10': (68,),
  'F11': (87,),
  'F12': (88,),
  'F13': (100,),
  'F14': (101,),
  'F15': (102,),
  'F16': (103,),
  'F17': (104,),
  'F18': (105,),
  'F19': (106,),
  'F2': (60,),
  'F20': (107,),
  'F21': (108,),
  'F22': (109,),
  'F23': (110,),
  'F24': (118,),
  'F3': (61,),
  'F4': (62,),
  'F5': (63,),
  'F6': (64,),
  'F7': (65,),
  'F8': (66,),
  'F9': (67,),
  'G': (34,),
  'GREATER': (52,),
  'H': (35,),
  'HANGUEL': (242,),
  'HANJA': (241,),
  'HENKAN': (121,),
  'HIRAGANA': (119,),
  'HIRAGANA_KATAKANA': (112,),
  'HOME': (224, 71),
  'I': (23,),
  'INSERT': (224, 82),
  'J': (36,),
  'K': (37,),
  'KATAKANA': (120,),
  'L': (38,),
  'LEFT': (224, 75),
  'LESS': (51,),
  'LESS_GREATER': (86,),
  'M': (50,),
  'MEDIA_NEXT_TRACK': (224, 25),
  'MEDIA_PLAY_PAUSE': (224, 34),
  'MEDIA_PREV_TRACK': (224, 16),
  'MEDIA_SELECT': (224, 109),
  'MEDIA_STOP': (224, 36),
  'MENU': (224, 93),
  'MINUS': (12,),
  'MUHENKAN': (123,),
  'MUTE': (224, 32),
  'N': (49,),
  'NUM_0': (11,),
  'NUM_1': (2,),
  'NUM_2': (3,),
  'NUM_3': (4,),
  'NUM_4': (5,),
  'NUM_5': (6,),
  'NUM_6': (7,),
  'NUM_7': (8,),
  'NUM_8': (9,),
  'NUM_9': (10,),
  'NUM_LOCK': (69,),
  'O': (24,),
  'P': (25,),
  'PAD_0': (82,),
  'PAD_1': (79,),
  'PAD_2': (80,),
  'PAD_3': (81,),
  'PAD_4': (75,),
  'PAD_5': (76,),
  'PAD_6': (77,),
  'PAD_7': (71,),
  'PAD_8': (72,),
  'PAD_9': (73,),
  'PAD_DEL': (83,),
  'PAD_ENTER': (224, 28),
  'PAD_EQUAL': (89,),
  'PAD_MINUS': (74,),
  'PAD_PLUS': (78,),
  'PAD_SLASH': (224, 53),
  'PAD_STAR': (55,),
  'PAGE_DOWN': (224, 81),
  'PAGE_UP': (224, 73),
  'PAUSE_BREAK': (225, 29, 69, 225, 157, 197),
  'PC9800_KEYPAD': (92,),
  'PLUS': (13,),
  'PRINT_SCREEN': (224, 42, 224, 55),
  'PRINT_SCREEN2': (224, 55),
  'Q': (16,),
  'QUOTE': (40,),
  'R': (19,),
  'RIGHT': (224, 77),
  'RO': (115,),
  'S': (31,),
  'SCROLL_LOCK': (70,),
  'SHIFT_LEFT': (42,),
  'SHIFT_RIGHT': (54,),
  'SLASH': (53,),
  'SPACE': (57,),
  'SYSRQ': (84,),
  'SYSTEM_POWER': (224, 94),
  'SYSTEM_SLEEP': (224, 95),
  'SYSTEM_WAKE': (224, 99),
  'T': (20,),
  'TAB': (15,),
  'TILDA': (41,),
  'U': (22,),
  'UP': (224, 72),
  'V': (47,),
  'VOLUME_DOWN': (224, 46),
  'VOLUME_UP': (224, 48),
  'W': (17,),
  'WWW_BACK': (224, 106),
  'WWW_FAVORITES': (224, 102),
  'WWW_FORWARD': (224, 105),
  'WWW_HOME': (224, 50),
  'WWW_REFRESH': (224, 103),
  'WWW_SEARCH': (224, 101),
  'WWW_STOP': (224, 104),
  'X': (45,),
  'Y': (21,),
  'YEN': (125,),
  'Z': (44,),
  'ZENKAKU_HANKAKU': (118,)
}
```

</details>

## Current implementation and changes in this PR

### Current behavior of `prltype.py`

1. A sequence of scancodes is received from the PC-XT driver as the second argument to `prltype.py`
1. The `send()` function in `prltype.py` loops over the list of scancodes
1. If the decimal value of the scancode is < 128, send a single-member tuple holding the decimal value to the parallels API, as a `PRESS`.
1. If the decimal value of a scancode is > 128, subtract 128. Send a single-member tuple holding the remainder to the parallels API, as a `RELEASE`.

There is no parsing of incoming scancodes to determine sequences; all scancodes are sent as single-member tuples.

### Updated `prltype.py` behavior in this PR

1. Loop over enumerated list of scancodes, with the index
1. When an `e0` scancode is received, `pop()` the next scancode in the list.
1. If the decimal value of the second scancode is < 128, this is a `PRESS`.
1. If the decimal value of the second scancode is > 128, subtract 128, This is a `RELEASE`.
1. Create a two-member tuple with the first and second scancodes, and send the event to the Parallels API.

### Additional updates in this PR

- Update `prltype.py` style
  - Run `black` to fix indentation, whitespace
  - Remove `##` marks
  - Update Go comment describing `prltype.py`

- Rename `timeout` variable to `delay`.
  - The `prlsdkapi.vm_io.send_key_event()` function has no _timeout_ parameter. The little [documentation I could](https://download.parallels.com/desktop/v16/docs/en_US/Parallels%20Python%20API%20Reference/prlsdkapi.VmIO-class.html) find describes the final param for `send_key_event()` as being a delay, in milliseconds. I have experimented with different values and confirmed the behavior is a delay between keystrokes.

- Increase default `delay` value from 10ms to 100ms.
  - 10ms seems to be to be an unreasonable default (and hashicorp/packer#8930 agrees, in general). On macOS VMs, keys are lost with a delay of 10ms, making the `boot_command` barely usable. I think ideally `PACKER_KEY_INTERVAL` would be nice to use here, but doesn't seem to be supported in the PC-XT driver. For now, setting a more idiomatic default seems like a reasonable solution.

## Testing template

While debugging this plugin it was helpful to be able to see what keystrokes the system was receiving. The template below uses a Debian Live iso and `xkeycaps` to provide a way to visually debug the typed boot command.

```hcl
packer {
  required_version = ">= 1.7.2"
}

# "timestamp" template function replacement
locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }


source "parallels-iso" "min" {
  boot_command           = [
    "<enter><wait70>t<bs>konsole<wait5><enter><wait5>",
    "sudo apt-get update<enter><wait15>",
    "sudo apt-get -yqq install xkeycaps<enter><wait10>",
    "xkeycaps -keyboard PC105<enter><wait5>",
    "ThE qUiCk BrOwN fOx JuMpS oVeR tHe LaZy DoG",
    "<leftCtrlOn><leftAltOn><leftSuperOn><leftCtrlOff><leftAltOff><leftSuperOff>",
    "<rightCtrlOn><rightAltOn><rightSuperOn><rightCtrlOff><rightAltOff><rightSuperOff>",
    "<up><down><left><right><spacebar>",
    "`~1!2@3#4$5%6^7&8*9(0)-_=+",
    "[]{}\\|;:\\'\".>,</?",
    "ThEqUiCkBrOwNfOxJuMpSoVeRtHeLaZyDoGThEqUiCkBrOwNfOxJuMpSoVeRtHeLaZyDoGThEqUiCkBrOwNfOxJuMpSoVeRtHeLaZyDoGThEqUiCkBrOwNfOxJuMpSoVeRtHeLaZyDoG",
  ]
  boot_wait              = "5s"
  boot_keygroup_interval = "20s" # Can't yet confirm this works.
  cpus                   = 4
  disk_size              = 8000
  memory                 = 4000
  guest_os_type          = "debian"
  iso_url                = "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-10.9.0-amd64-kde.iso"
  iso_checksum           = "none"
  parallels_tools_flavor = "lin"
  prlctl                 = [
    ["set", "{{.Name}}", "--startup-view", "window"]
  ]
  ssh_timeout            = "5m"
  ssh_username           = "packer"
  ssh_password           = "packer"
  vm_name                = "keytest-${local.timestamp}"
}

build {
  name    = "min"
  sources = ["source.parallels-iso.min"]
}
```

## References

- [Parallels Python API Reference](https://download.parallels.com/desktop/v16/docs/en_US/Parallels%20Python%20API%20Reference/)
- [Parallels Virtualization SDK - C API Reference](https://download.parallels.com/desktop/v16/docs/en_US/Parallels%20C%20API%20Reference/frames.html?frmname=topic&frmfile=index.html)
- [Parallels Virtualization SDK Programmer's Guide](https://download.parallels.com/desktop/v16/docs/en_US/Parallels%20Virtualization%20SDK%20Programmer's%20Guide.pdf)
- [Scancodes table](http://www.vetra.com/scancodes.html)


