### PR TITLE
Check for prlsdkapi

### DIFF
--- a/builder/parallels/common/driver.go
+++ b/builder/parallels/common/driver.go
@@ -75,6 +75,13 @@ func NewDriver() (Driver, error) {
 			"Parallels builder works only on \"darwin\" platform!")
 	}
 
+	cmd := exec.Command("/usr/bin/python", "-c", `import prlsdkapi`)
+	err := cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Parallels Virtualization SDK is not installed")
+	}
+
 	if prlctlPath == "" {
 		var err error
 		prlctlPath, err = exec.LookPath("prlctl")


### PR DESCRIPTION
This PR adds a check to ensure that the Parallels Virtualization SDK is installed.

The SDK installs its python 2 Library to `/Library/Frameworks/ParallelsVirtualizationSDK.framework/Libraries/Python/2.7/prlsdkapi/`, which makes `prlsdkapi` available to system python.

The `prltype.py` script inside of `prltype.go` uses `prlsdkapi` to type the boot command. We can verify that the Parallels SDK is installed by trying to import `prlsdkapi` from system python.

Since `prltype.go` hasn't been touched in 4 years, and Python 2 has since been EOL'd (but still ships with macOS, for now), it's worth mentioning that the Pro Edition of Parallels Desktop now supports a Python 3 version of `prlsdkapi`.

Closes #3 