### PR TITLE
Change python 2.7 to python 3 due to removal of python 2.7 in macOS 12.3

### DIFF
--- a/builder/parallels/common/driver.go
+++ b/builder/parallels/common/driver.go
@@ -75,7 +75,7 @@ func NewDriver() (Driver, error) {
 			"Parallels builder works only on \"darwin\" platform!")
 	}
 
-	cmd := exec.Command("/usr/bin/python", "-c", `import prlsdkapi`)
+	cmd := exec.Command("/usr/bin/python3", "-c", `import prlsdkapi`)
 	err := cmd.Run()
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/builder/parallels/common/driver_9.go
+++ b/builder/parallels/common/driver_9.go
@@ -304,7 +304,7 @@ func (d *Parallels9Driver) SendKeyScanCodes(vmName string, codes ...string) erro
 
 	args := prepend(vmName, codes)
 	args = prepend(f.Name(), args)
-	cmd := exec.Command("/usr/bin/python", args...)
+	cmd := exec.Command("/usr/bin/python3", args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err = cmd.Run()

--- a/builder/parallels/common/prltype.go
+++ b/builder/parallels/common/prltype.go
@@ -9,7 +9,7 @@ import prlsdkapi
 
 def main():
     if len(sys.argv) < 3:
-        print "Usage: prltype VM_NAME SCANCODE..."
+        print("Usage: prltype VM_NAME SCANCODE...")
         sys.exit(1)
 
     vm_name = sys.argv[1]


### PR DESCRIPTION
This PR changes dependencies for python 2.7 to python 3 due to removal of python 2.7 support in macOS 12.3
https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes#Python

Build and tested on macOS 12.3 (Apple Silicon) with Parallels Desktop 17.1.1
