### PR TITLE
builder: remove unnecessary fmt.Sprintf

### DIFF
--- a/builder/parallels/iso/step_set_boot_order.go
+++ b/builder/parallels/iso/step_set_boot_order.go
@@ -28,7 +28,7 @@ func (s *stepSetBootOrder) Run(ctx context.Context, state multistep.StateBag) mu
 	ui.Say("Setting the boot order...")
 	command := []string{
 		"set", vmName,
-		"--device-bootorder", fmt.Sprintf("hdd0 cdrom0 net0"),
+		"--device-bootorder", "hdd0 cdrom0 net0",
 	}
 
 	if err := driver.Prlctl(command...); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -85,4 +85,5 @@ require (
 	google.golang.org/grpc v1.40.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -991,7 +991,6 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
golangci-lint points out an unnecessary fmt.Sprintf without a format-string and dynamic values, so we can safely remove it.

