### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -16,12 +16,12 @@ Packer actually comes with multiple builders able to create Parallels machines,
 depending on the strategy you want to use to build the image. Packer supports
 the following Parallels builders:
 
-- [parallels-iso](/docs/builders/parallels-iso) - Starts from an ISO
+- [parallels-iso](/packer/plugins/builders/parallels/iso) - Starts from an ISO
   file, creates a brand new Parallels VM, installs an OS, provisions software
   within the OS, then exports that machine to create an image. This is best
   for people who want to start from scratch.
 
-- [parallels-pvm](/docs/builders/parallels-pvm) - This builder imports
+- [parallels-pvm](/packer/plugins/builders/parallels/pvm) - This builder imports
   an existing PVM file, runs provisioners on top of that VM, and exports that
   machine to create an image. This is best if you have an existing Parallels
   VM export you want to use as the source. As an additional benefit, you can

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -54,7 +54,7 @@ are organized below into two categories: required and optional. Within each
 category, the available options are alphabetized and described.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder. In addition to the options defined there, a private key file
 can also be supplied to override the typical auto-generated key:
 
@@ -159,7 +159,7 @@ can also be supplied to override the typical auto-generated key:
 - `parallels_tools_guest_path` (string) - The path in the virtual machine to
   upload Parallels Tools. This only takes effect if `parallels_tools_mode`
   is "upload". This is a [configuration
-  template](/docs/templates/legacy_json_templates/engine) that has a single
+  template](/packer/docs/templates/legacy_json_templates/engine) that has a single
   valid variable: `Flavor`, which will be the value of
   `parallels_tools_flavor`. By default this is `prl-tools-{{.Flavor}}.iso`
   which should upload into the login directory of the user.
@@ -178,7 +178,7 @@ can also be supplied to override the typical auto-generated key:
   itself as an array of strings, where each string represents a single
   argument on the command-line to `prlctl` (but excluding `prlctl` itself).
   Each arg is treated as a [configuration
-  template](/docs/templates/legacy_json_templates/engine), where the `Name`
+  template](/packer/docs/templates/legacy_json_templates/engine), where the `Name`
   variable is replaced with the VM name. More details on how to use `prlctl`
   are below.
 
@@ -237,7 +237,7 @@ all typed in sequence. It is an array only to improve readability within the
 template.
 
 The boot command is "typed" character for character (using the Parallels
-Virtualization SDK, see [Parallels Builder](/docs/builders/parallels))
+Virtualization SDK, see [Parallels Builder](/packer/plugin/builders/parallels))
 simulating a human actually typing the keyboard.
 
 There are a set of special keys available. If these are in your boot
@@ -297,7 +297,7 @@ To hold the `c` key down, you would use `<cOn>`. Likewise, `<cOff>` to release.
 ### Templates inside boot command
 
 In addition to the special keys, each command to type is treated as a
-[template engine](/docs/templates/legacy_json_templates/engine). The
+[template engine](/packer/docs/templates/legacy_json_templates/engine). The
 available variables are:
 
 - `HTTPIP` and `HTTPPort` - The IP and port, respectively of an HTTP server
@@ -356,6 +356,6 @@ executed in the order defined. So in the above example, 3d acceleration will be 
 first, followed by the command which enables the adaptive hypervisor.
 
 Each command itself is an array of strings, where each string is an argument to
-`prlctl`. Each argument is treated as a [template engine](/docs/templates/legacy_json_templates/engine). The only available
+`prlctl`. Each argument is treated as a [template engine](/packer/docs/templates/legacy_json_templates/engine). The only available
 variable is `Name` which is replaced with the unique name of the VM, which is
 required for many `prlctl` calls.

--- a/docs/builders/pvm.mdx
+++ b/docs/builders/pvm.mdx
@@ -51,7 +51,7 @@ are organized below into two categories: required and optional. Within each
 category, the available options are alphabetized and described.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder. In addition to the options defined there, a private key file
 can also be supplied to override the typical auto-generated key:
 
@@ -113,7 +113,7 @@ can also be supplied to override the typical auto-generated key:
 - `parallels_tools_guest_path` (string) - The path in the VM to upload
   Parallels Tools. This only takes effect if `parallels_tools_mode`
   is "upload". This is a [configuration
-  template](/docs/templates/legacy_json_templates/engine) that has a single
+  template](/packer/docs/templates/legacy_json_templates/engine) that has a single
   valid variable: `Flavor`, which will be the value of
   `parallels_tools_flavor`. By default this is `prl-tools-{{.Flavor}}.iso`
   which should upload into the login directory of the user.
@@ -132,7 +132,7 @@ can also be supplied to override the typical auto-generated key:
   itself as an array of strings, where each string represents a single
   argument on the command-line to `prlctl` (but excluding `prlctl` itself).
   Each arg is treated as a [configuration
-  template](/docs/templates/legacy_json_templates/engine), where the `Name`
+  template](/packer/docs/templates/legacy_json_templates/engine), where the `Name`
   variable is replaced with the VM name. More details on how to use `prlctl`
   are below.
 
@@ -188,7 +188,7 @@ all typed in sequence. It is an array only to improve readability within the
 template.
 
 The boot command is "typed" character for character (using the Parallels
-Virtualization SDK, see [Parallels Builder](/docs/builders/parallels))
+Virtualization SDK, see [Parallels Builder](/packer/plugins/builders/parallels))
 simulating a human actually typing the keyboard.
 
 There are a set of special keys available. If these are in your boot
@@ -248,7 +248,7 @@ To hold the `c` key down, you would use `<cOn>`. Likewise, `<cOff>` to release.
 ### Templates inside boot command
 
 In addition to the special keys, each command to type is treated as a
-[template engine](/docs/templates/legacy_json_templates/engine). The
+[template engine](/packer/docs/templates/legacy_json_templates/engine). The
 available variables are:
 
 - `HTTPIP` and `HTTPPort` - The IP and port, respectively of an HTTP server
@@ -288,6 +288,6 @@ followed by the CPUs.
 
 Each command itself is an array of strings, where each string is an argument to
 `prlctl`. Each argument is treated as a [configuration
-template](/docs/templates/legacy_json_templates/engine). The only available
+template](/packer/docs/templates/legacy_json_templates/engine). The only available
 variable is `Name` which is replaced with the unique name of the VM, which is
 required for many `prlctl` calls.


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them