### PR TITLE
.gitignore: ignore crash.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/*
 packer-plugin-parallels
 example/output-ubuntu1804
 .docs
+crash.log


### PR DESCRIPTION
The crash.log file is an artifact from testing, and should not be tracked by Git.