### PR TITLE
add support for --cpu-type when creating VM

### DIFF
--- a/builder/parallels/common/hw_config.go
+++ b/builder/parallels/common/hw_config.go
@@ -15,6 +15,10 @@ type HWConfig struct {
 	// The number of cpus to use for building the VM.
 	// Defaults to 1.
 	CpuCount int `mapstructure:"cpus" required:"false"`
+	// The CPU type to use for building the VM.
+	// Valid values are "x86" or "arm". If not specified, Parallels will use
+	// the default CPU type for the host architecture.
+	CpuType string `mapstructure:"cpu_type" required:"false"`
 	// The amount of memory to use for building the VM in
 	// megabytes. Defaults to 512 megabytes.
 	MemorySize int `mapstructure:"memory" required:"false"`
@@ -35,6 +39,10 @@ func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
 	}
 	if c.CpuCount == 0 {
 		c.CpuCount = 1
+	}
+
+	if c.CpuType != "" && c.CpuType != "x86" && c.CpuType != "arm" {
+		errs = append(errs, fmt.Errorf("An invalid cpu_type was specified. Valid values are 'x86' or 'arm': %s", c.CpuType))
 	}
 
 	if c.MemorySize < 0 {

--- a/builder/parallels/ipsw/builder.hcl2spec.go
+++ b/builder/parallels/ipsw/builder.hcl2spec.go
@@ -31,6 +31,7 @@ type FlatConfig struct {
 	BootCommand               []string                      `mapstructure:"boot_command" cty:"boot_command" hcl:"boot_command"`
 	OutputDir                 *string                       `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
 	CpuCount                  *int                          `mapstructure:"cpus" required:"false" cty:"cpus" hcl:"cpus"`
+	CpuType                   *string                       `mapstructure:"cpu_type" required:"false" cty:"cpu_type" hcl:"cpu_type"`
 	MemorySize                *int                          `mapstructure:"memory" required:"false" cty:"memory" hcl:"memory"`
 	Sound                     *bool                         `mapstructure:"sound" required:"false" cty:"sound" hcl:"sound"`
 	USB                       *bool                         `mapstructure:"usb" required:"false" cty:"usb" hcl:"usb"`
@@ -133,6 +134,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"boot_command":                 &hcldec.AttrSpec{Name: "boot_command", Type: cty.List(cty.String), Required: false},
 		"output_directory":             &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
 		"cpus":                         &hcldec.AttrSpec{Name: "cpus", Type: cty.Number, Required: false},
+		"cpu_type":                     &hcldec.AttrSpec{Name: "cpu_type", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"sound":                        &hcldec.AttrSpec{Name: "sound", Type: cty.Bool, Required: false},
 		"usb":                          &hcldec.AttrSpec{Name: "usb", Type: cty.Bool, Required: false},

--- a/builder/parallels/iso/builder.hcl2spec.go
+++ b/builder/parallels/iso/builder.hcl2spec.go
@@ -42,6 +42,7 @@ type FlatConfig struct {
 	BootCommand               []string          `mapstructure:"boot_command" cty:"boot_command" hcl:"boot_command"`
 	OutputDir                 *string           `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
 	CpuCount                  *int              `mapstructure:"cpus" required:"false" cty:"cpus" hcl:"cpus"`
+	CpuType                   *string           `mapstructure:"cpu_type" required:"false" cty:"cpu_type" hcl:"cpu_type"`
 	MemorySize                *int              `mapstructure:"memory" required:"false" cty:"memory" hcl:"memory"`
 	Sound                     *bool             `mapstructure:"sound" required:"false" cty:"sound" hcl:"sound"`
 	USB                       *bool             `mapstructure:"usb" required:"false" cty:"usb" hcl:"usb"`
@@ -157,6 +158,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"boot_command":                 &hcldec.AttrSpec{Name: "boot_command", Type: cty.List(cty.String), Required: false},
 		"output_directory":             &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
 		"cpus":                         &hcldec.AttrSpec{Name: "cpus", Type: cty.Number, Required: false},
+		"cpu_type":                     &hcldec.AttrSpec{Name: "cpu_type", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"sound":                        &hcldec.AttrSpec{Name: "sound", Type: cty.Bool, Required: false},
 		"usb":                          &hcldec.AttrSpec{Name: "usb", Type: cty.Bool, Required: false},

--- a/builder/parallels/iso/step_create_vm.go
+++ b/builder/parallels/iso/step_create_vm.go
@@ -31,12 +31,18 @@ func (s *stepCreateVM) Run(ctx context.Context, state multistep.StateBag) multis
 
 	commands := make([][]string, 3)
 
-	commands[0] = []string{
+	createCmd := []string{
 		"create", name,
 		"--distribution", config.GuestOSType,
 		"--dst", config.OutputDir,
 		"--no-hdd",
 	}
+
+	if config.HWConfig.CpuType != "" {
+		createCmd = append(createCmd, "--cpu-type", config.HWConfig.CpuType)
+	}
+
+	commands[0] = createCmd
 	commands[1] = []string{
 		"set", name,
 		"--cpus", strconv.Itoa(config.HWConfig.CpuCount),

--- a/docs-partials/builder/parallels/common/HWConfig-not-required.mdx
+++ b/docs-partials/builder/parallels/common/HWConfig-not-required.mdx
@@ -3,6 +3,10 @@
 - `cpus` (int) - The number of cpus to use for building the VM.
   Defaults to 1.
 
+- `cpu_type` (string) - The CPU type to use for building the VM.
+  Valid values are "x86" or "arm". If not specified, Parallels will use
+  the default CPU type for the host architecture.
+
 - `memory` (int) - The amount of memory to use for building the VM in
   megabytes. Defaults to 512 megabytes.
 


### PR DESCRIPTION
I've tried to locally build an image to use in a cloud provider, but I figured out I can't do it since this plugin only allows creating ARM VMs (even though Parallels [support](https://kb.parallels.com/130217) running x86 VMs). This PR fixes it by allowing the override of --cpu-type when creating a VM.

One moment: since HWConfig is shared between ISO and IPSW builders, it was also added to the second one (even though it doesn't make sense since IPSW is only for macOS images built for ARM processors). I'm not sure what to do with it: should I add some extra validation to disallow passing x86 in this builder, or should I separate this parameter out of HWConfig to make it present only for the ISO builder?